### PR TITLE
Recognizes Public/Private option

### DIFF
--- a/Pastebin.wdgt/pastebin.html
+++ b/Pastebin.wdgt/pastebin.html
@@ -33,7 +33,7 @@
       </tr>
       <tr>
         <td><label for="paste_private">Post exposure:</label></td>
-        <td><select name="paste_private"><option value="0">Public</option><option value="1">Private</option></select></td>
+        <td><select id="paste_private"><option value="0">Public</option><option value="1">Private</option></select></td>
       </tr>
       <!--<tr>
         <td><label for="paste_subdomain">Subdomain:</label></td>


### PR DESCRIPTION
Previously, the "#paste_private" would always return 0.  I've confirmed that the change works with a couple test uploads.
